### PR TITLE
fix: delete thumbnails of clips along with clips themselves

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "glipper",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "An easy utility for game clip cutting.",
 	"main": "./out/main/index.js",
 	"author": "Jakub Tabacek",

--- a/src/main/clipOperations.ts
+++ b/src/main/clipOperations.ts
@@ -57,6 +57,11 @@ export async function cutClip(clipId: string, reqData: ClipCutData) {
 
 						if (reqData.removeOriginal) {
 							fs.unlinkSync(oldClipPath)
+
+							const thumbPath = path.join(settings.gameFolder, 'thumbs', clip.filename + '.jpg')
+							if (fs.existsSync(thumbPath)) {
+								fs.unlinkSync(thumbPath)
+							}
 							await prisma.clip.delete({ where: { id: clipId } })
 						}
 
@@ -114,6 +119,11 @@ export async function deleteClip(clipId: string) {
 		if (!clip) return
 
 		fs.unlinkSync(path.join(settings.gameFolder, clip.gameName, clip.filename))
+
+		const thumbPath = path.join(settings.gameFolder, 'thumbs', clip.filename + '.jpg')
+		if (fs.existsSync(thumbPath)) {
+			fs.unlinkSync(thumbPath)
+		}
 
 		await prisma.clip.delete({ where: { id: clipId } })
 		clipsList(clip.gameName)

--- a/src/renderer/src/components/Header.vue
+++ b/src/renderer/src/components/Header.vue
@@ -2,7 +2,7 @@
 	<div class="bg-gray-800 py-2 w-full flex justify-between items-center relative">
 		<div class="flex items-center">
 			<h5 class="font-black text-2xl ml-4 mr-2">GLIPPER</h5>
-			<Badge value="v1.0.2 | BETA" class="mt-1" severity="primary"></Badge>
+			<Badge :value="appVersion" class="mt-1" severity="primary"></Badge>
 
 			<Button
 				v-if="mainStore.selectedGame"
@@ -56,6 +56,8 @@ const lastCheck = computed(() => {
 	if (!mainStore.settings?.lastGameDBUpdate) return null
 	else return formatDistanceToNow(new Date(mainStore.settings.lastGameDBUpdate), { addSuffix: true })
 })
+
+const appVersion = computed(() => `v${window.electron.process.env.npm_package_version} | BETA`)
 
 const handleRefreshClick = () => {
 	window.electron.ipcRenderer.invoke('buildGameDB')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced cleanup process for clips, ensuring both original clips and their thumbnails are deleted when a clip is cut or deleted.
	- Improved management of associated clips by removing them from the database when related games are deleted.
	- Dynamic version display in the header, reflecting the updated app version.

- **Bug Fixes**
	- Fixed issues with lingering thumbnail files by adding checks to delete them when clips are removed from the database.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->